### PR TITLE
Dockerイメージのサイズ最適化 part.1

### DIFF
--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -1,13 +1,21 @@
-FROM golang:1.24
-
-WORKDIR /app
+# ---- Build stage ----
+FROM golang:1.24 AS build
+WORKDIR /src
 
 COPY go.mod go.sum ./
 RUN go mod download
 
 COPY . .
+ENV CGO_ENABLED=0 GOOS=linux GOARCH=amd64
+RUN go build -trimpath -ldflags="-s -w" -buildvcs=false -o /out/app ./server.go
 
-RUN go mod tidy
-RUN go build -o main .
+# ---- Run stage (distroless) ----
+FROM gcr.io/distroless/static-debian12
+# Cloud Run/Neon/Firebase で TLS が必要 → distroless なら CA 同梱済み
+WORKDIR /app
+COPY --from=build /out/app /app/app
 
-CMD ["./main"]
+USER nonroot:nonroot
+ENV PORT=8080
+
+ENTRYPOINT ["/app/app"]

--- a/server/Dockerfile.dev
+++ b/server/Dockerfile.dev
@@ -2,7 +2,7 @@ FROM golang:1.24
 
 WORKDIR /app
 
-RUN go install github.com/air-verse/air@latest
+RUN go install github.com/air-verse/air@v1.52.3
 
 COPY go.mod go.sum ./
 RUN go mod download

--- a/server/README.md
+++ b/server/README.md
@@ -387,8 +387,6 @@ main ブランチへのマージをトリガーにデプロイが実行されま
 
 ### Artifact Registryへの手動イメージプッシュ
 
-**注意**: 本番デプロイはGitHub Actionsで自動化予定です。以下は手動でプッシュする場合のコマンドです。
-
 ```bash
 # プロジェクトIDとリポジトリ名を設定
 export PROJECT_ID="fitness-app-prd"


### PR DESCRIPTION
## 概要
<!-- このPRの目的と概要を簡潔に説明してください -->

Cloud Run で動かしてるイメージサイズが大きい(600MB)ので、サイズの最適化を行う。
まずはAPIサーバのコンテナイメージから

## 変更点
<!-- 具体的な変更点や修正箇所をリストアップしてください -->

- Dockerfile にマルチステージビルドを適用

## テスト
<!-- このPRに関連するテストケースやテスト方法を記載してください -->

- ccc
- ddd

## 備考