### PR TITLE
RevenueCat 導入

### DIFF
--- a/client/components/layout/SettingsScreen.tsx
+++ b/client/components/layout/SettingsScreen.tsx
@@ -4,6 +4,7 @@ import { useRouter } from "expo-router";
 import { useState } from "react";
 import FontAwesome from '@expo/vector-icons/FontAwesome';
 import { useTheme } from "../../theme";
+import { SubscriptionStatus, SubscriptionPurchase } from "../ui";
 
 const createStyles = (theme: any) => StyleSheet.create({
   container: {
@@ -162,6 +163,11 @@ export function SettingsScreen() {
           <FontAwesome name="chevron-right" size={16} color={theme.textTertiary} />
         </TouchableOpacity>
       </View>
+
+      {/* サブスクリプションセクション */}
+      <Text style={styles.sectionHeader}>サブスクリプション</Text>
+      <SubscriptionStatus entitlementId="premium" showDetails={true} />
+      <SubscriptionPurchase entitlementId="premium" />
 
       {/* アカウントセクション */}
       <Text style={styles.sectionHeader}>アカウント</Text>

--- a/client/components/ui/SubscriptionPurchase.tsx
+++ b/client/components/ui/SubscriptionPurchase.tsx
@@ -1,0 +1,211 @@
+import React from 'react';
+import {
+  View,
+  Text,
+  TouchableOpacity,
+  StyleSheet,
+  Alert,
+  ActivityIndicator
+} from 'react-native';
+import { useRevenueCat } from '../../hooks/useRevenueCat';
+import { useTheme } from '../../theme';
+import { PurchasesPackage } from 'react-native-purchases';
+
+interface SubscriptionPurchaseProps {
+  entitlementId: string;
+  offeringId?: string;
+}
+
+export const SubscriptionPurchase: React.FC<SubscriptionPurchaseProps> = ({
+  entitlementId,
+  offeringId
+}) => {
+  const { theme } = useTheme();
+  const {
+    offerings,
+    purchasePackage,
+    restoreUserPurchases,
+    isPurchasing,
+    isRestoring,
+    checkEntitlement
+  } = useRevenueCat();
+
+  const styles = createStyles(theme);
+
+  // 既にサブスクリプションを持っている場合は何も表示しない
+  if (checkEntitlement(entitlementId)) {
+    return (
+      <View style={styles.container}>
+        <Text style={styles.alreadySubscribedText}>
+          既にサブスクリプションに加入しています
+        </Text>
+      </View>
+    );
+  }
+
+  // オファリングを取得
+  const offering = offeringId
+    ? offerings.find(o => o.identifier === offeringId)
+    : offerings[0]; // 最初のオファリングを使用
+
+  if (!offering || !offering.availablePackages.length) {
+    return (
+      <View style={styles.container}>
+        <Text style={styles.noOfferingsText}>
+          利用可能なサブスクリプションがありません
+        </Text>
+      </View>
+    );
+  }
+
+  const handlePurchase = async (packageToPurchase: PurchasesPackage) => {
+    try {
+      await purchasePackage(packageToPurchase);
+      Alert.alert('成功', 'サブスクリプションの購入が完了しました！');
+    } catch (error) {
+      console.error('Purchase error:', error);
+      Alert.alert('エラー', '購入に失敗しました。もう一度お試しください。');
+    }
+  };
+
+  const handleRestore = async () => {
+    try {
+      await restoreUserPurchases();
+      Alert.alert('成功', '購入履歴の復元が完了しました！');
+    } catch (error) {
+      console.error('Restore error:', error);
+      Alert.alert('エラー', '復元に失敗しました。もう一度お試しください。');
+    }
+  };
+
+  return (
+    <View style={styles.container}>
+      <Text style={styles.title}>サブスクリプション</Text>
+
+      {offering.availablePackages.map((pkg) => (
+        <View key={pkg.identifier} style={styles.packageContainer}>
+          <View style={styles.packageInfo}>
+            <Text style={styles.packageTitle}>{pkg.product.title}</Text>
+            <Text style={styles.packageDescription}>{pkg.product.description}</Text>
+            <Text style={styles.packagePrice}>{pkg.product.priceString}</Text>
+          </View>
+
+          <TouchableOpacity
+            style={[
+              styles.purchaseButton,
+              isPurchasing && styles.disabledButton
+            ]}
+            onPress={() => handlePurchase(pkg)}
+            disabled={isPurchasing || isRestoring}
+          >
+            {isPurchasing ? (
+              <ActivityIndicator size="small" color="#fff" />
+            ) : (
+              <Text style={styles.purchaseButtonText}>購入</Text>
+            )}
+          </TouchableOpacity>
+        </View>
+      ))}
+
+      <TouchableOpacity
+        style={[
+          styles.restoreButton,
+          isRestoring && styles.disabledButton
+        ]}
+        onPress={handleRestore}
+        disabled={isPurchasing || isRestoring}
+      >
+        {isRestoring ? (
+          <ActivityIndicator size="small" color={theme.secondary} />
+        ) : (
+          <Text style={styles.restoreButtonText}>購入履歴を復元</Text>
+        )}
+      </TouchableOpacity>
+    </View>
+  );
+};
+
+const createStyles = (theme: any) => StyleSheet.create({
+  container: {
+    backgroundColor: theme.surface,
+    marginVertical: 8,
+    borderRadius: 12,
+    marginHorizontal: 16,
+    padding: 16,
+  },
+  title: {
+    fontSize: 20,
+    fontWeight: 'bold',
+    marginBottom: 16,
+    textAlign: 'center',
+    color: theme.text,
+  },
+  packageContainer: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    padding: 12,
+    borderWidth: 1,
+    borderColor: theme.border,
+    borderRadius: 8,
+    marginBottom: 12,
+    backgroundColor: theme.background,
+  },
+  packageInfo: {
+    flex: 1,
+  },
+  packageTitle: {
+    fontSize: 16,
+    fontWeight: 'bold',
+    color: theme.text,
+    marginBottom: 4,
+  },
+  packageDescription: {
+    fontSize: 14,
+    color: theme.textSecondary,
+    marginBottom: 4,
+  },
+  packagePrice: {
+    fontSize: 16,
+    fontWeight: 'bold',
+    color: theme.secondary,
+  },
+  purchaseButton: {
+    backgroundColor: theme.secondary,
+    paddingHorizontal: 16,
+    paddingVertical: 8,
+    borderRadius: 6,
+    minWidth: 80,
+    alignItems: 'center',
+  },
+  purchaseButtonText: {
+    color: '#fff',
+    fontWeight: 'bold',
+  },
+  restoreButton: {
+    backgroundColor: 'transparent',
+    borderWidth: 1,
+    borderColor: theme.secondary,
+    paddingVertical: 12,
+    borderRadius: 6,
+    alignItems: 'center',
+    marginTop: 8,
+  },
+  restoreButtonText: {
+    color: theme.secondary,
+    fontWeight: 'bold',
+  },
+  disabledButton: {
+    opacity: 0.6,
+  },
+  alreadySubscribedText: {
+    fontSize: 16,
+    color: theme.success,
+    textAlign: 'center',
+    fontWeight: 'bold',
+  },
+  noOfferingsText: {
+    fontSize: 16,
+    color: theme.textSecondary,
+    textAlign: 'center',
+  },
+});

--- a/client/components/ui/SubscriptionStatus.tsx
+++ b/client/components/ui/SubscriptionStatus.tsx
@@ -1,0 +1,120 @@
+import React from 'react';
+import { View, Text, StyleSheet, ActivityIndicator } from 'react-native';
+import { useSubscription } from '../../hooks/useRevenueCat';
+import { useTheme } from '../../theme';
+
+interface SubscriptionStatusProps {
+  entitlementId: string;
+  showDetails?: boolean;
+}
+
+export const SubscriptionStatus: React.FC<SubscriptionStatusProps> = ({
+  entitlementId,
+  showDetails = true
+}) => {
+  const { theme } = useTheme();
+  const {
+    isSubscribed,
+    subscriptionInfo,
+    customerInfo,
+    isPurchasing,
+    isRestoring
+  } = useSubscription(entitlementId);
+
+  const styles = createStyles(theme);
+
+  if (isPurchasing || isRestoring) {
+    return (
+      <View style={styles.container}>
+        <ActivityIndicator size="small" color={theme.secondary} />
+        <Text style={styles.loadingText}>
+          {isPurchasing ? '購入処理中...' : '復元処理中...'}
+        </Text>
+      </View>
+    );
+  }
+
+  return (
+    <View style={styles.container}>
+      <View style={styles.statusContainer}>
+        <View style={[
+          styles.statusIndicator,
+          { backgroundColor: isSubscribed ? theme.success : theme.error }
+        ]} />
+        <Text style={styles.statusText}>
+          {isSubscribed ? 'アクティブ' : '非アクティブ'}
+        </Text>
+      </View>
+
+      {showDetails && isSubscribed && subscriptionInfo && (
+        <View style={styles.detailsContainer}>
+          <Text style={styles.detailText}>
+            期間: {subscriptionInfo.periodType || '不明'}
+          </Text>
+          {subscriptionInfo.expirationDate && (
+            <Text style={styles.detailText}>
+              有効期限: {new Date(subscriptionInfo.expirationDate).toLocaleDateString('ja-JP')}
+            </Text>
+          )}
+          <Text style={styles.detailText}>
+            自動更新: {subscriptionInfo.willRenew ? '有効' : '無効'}
+          </Text>
+        </View>
+      )}
+
+      {customerInfo && (
+        <Text style={styles.customerIdText}>
+          顧客ID: {customerInfo.originalAppUserId}
+        </Text>
+      )}
+    </View>
+  );
+};
+
+const createStyles = (theme: any) => StyleSheet.create({
+  container: {
+    backgroundColor: theme.surface,
+    marginVertical: 8,
+    borderRadius: 12,
+    marginHorizontal: 16,
+    padding: 16,
+  },
+  statusContainer: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    marginBottom: 8,
+  },
+  statusIndicator: {
+    width: 12,
+    height: 12,
+    borderRadius: 6,
+    marginRight: 8,
+  },
+  statusText: {
+    fontSize: 16,
+    fontWeight: 'bold',
+    color: theme.text,
+  },
+  detailsContainer: {
+    marginTop: 8,
+    paddingTop: 8,
+    borderTopWidth: 1,
+    borderTopColor: theme.divider,
+  },
+  detailText: {
+    fontSize: 14,
+    color: theme.textSecondary,
+    marginBottom: 4,
+  },
+  customerIdText: {
+    fontSize: 12,
+    color: theme.textTertiary,
+    marginTop: 8,
+    fontStyle: 'italic',
+  },
+  loadingText: {
+    marginLeft: 8,
+    fontSize: 14,
+    color: theme.textSecondary,
+  },
+});

--- a/client/components/ui/index.ts
+++ b/client/components/ui/index.ts
@@ -12,3 +12,5 @@ export { GoogleIcon } from './GoogleIcon';
 export { QRCodeGenerator } from './QRCodeGenerator';
 export { QRCodeScanner } from './QRCodeScanner';
 export { AdBanner } from './AdBanner';
+export { SubscriptionStatus } from './SubscriptionStatus';
+export { SubscriptionPurchase } from './SubscriptionPurchase';

--- a/client/hooks/index.ts
+++ b/client/hooks/index.ts
@@ -7,3 +7,4 @@ export * from "./useWorkoutStats";
 export * from "./useFriendRequest";
 export * from "./useFriendshipActions";
 export * from "./useAdMob";
+export * from "./useRevenueCat";

--- a/client/hooks/useRevenueCat.ts
+++ b/client/hooks/useRevenueCat.ts
@@ -1,0 +1,127 @@
+import { useState, useCallback } from 'react';
+import { PurchasesPackage } from 'react-native-purchases';
+import {
+  makePurchase,
+  restorePurchases
+} from '../lib/revenuecat';
+import { useAuth } from './AuthContext';
+
+export const useRevenueCat = () => {
+  const {
+    customerInfo,
+    offerings,
+    revenueCatLoading,
+    revenueCatError,
+    refreshCustomerInfo,
+    refreshOfferings,
+    isEntitled,
+    getSubscriptionInfo,
+  } = useAuth();
+
+  const [isPurchasing, setIsPurchasing] = useState(false);
+  const [isRestoring, setIsRestoring] = useState(false);
+
+  // 購入処理
+  const purchasePackage = useCallback(async (packageToPurchase: PurchasesPackage) => {
+    try {
+      setIsPurchasing(true);
+      const customerInfo = await makePurchase(packageToPurchase);
+
+      // 購入後に顧客情報を更新
+      await refreshCustomerInfo();
+
+      return customerInfo;
+    } catch (error) {
+      console.error('Purchase failed:', error);
+      throw error;
+    } finally {
+      setIsPurchasing(false);
+    }
+  }, [refreshCustomerInfo]);
+
+  // 購入復元処理
+  const restoreUserPurchases = useCallback(async () => {
+    try {
+      setIsRestoring(true);
+      const customerInfo = await restorePurchases();
+
+      // 復元後に顧客情報を更新
+      await refreshCustomerInfo();
+
+      return customerInfo;
+    } catch (error) {
+      console.error('Restore failed:', error);
+      throw error;
+    } finally {
+      setIsRestoring(false);
+    }
+  }, [refreshCustomerInfo]);
+
+  // 特定のエンタイトルメントの確認
+  const checkEntitlement = useCallback((entitlementId: string) => {
+    return isEntitled(entitlementId);
+  }, [isEntitled]);
+
+  // サブスクリプション情報の取得
+  const getSubscriptionDetails = useCallback((entitlementId: string) => {
+    return getSubscriptionInfo(entitlementId);
+  }, [getSubscriptionInfo]);
+
+  // 利用可能なオファリングの取得
+  const getAvailableOfferings = useCallback(() => {
+    return offerings;
+  }, [offerings]);
+
+  // 特定のオファリングの取得
+  const getOfferingById = useCallback((offeringId: string) => {
+    return offerings.find(offering => offering.identifier === offeringId);
+  }, [offerings]);
+
+  return {
+    // 状態
+    customerInfo,
+    offerings,
+    isLoading: revenueCatLoading,
+    error: revenueCatError,
+    isPurchasing,
+    isRestoring,
+
+    // アクション
+    purchasePackage,
+    restoreUserPurchases,
+    refreshCustomerInfo,
+    refreshOfferings,
+
+    // ユーティリティ
+    checkEntitlement,
+    getSubscriptionDetails,
+    getAvailableOfferings,
+    getOfferingById,
+  };
+};
+
+// サブスクリプション管理専用のフック
+export const useSubscription = (entitlementId: string) => {
+  const {
+    customerInfo,
+    checkEntitlement,
+    getSubscriptionDetails,
+    purchasePackage,
+    restoreUserPurchases,
+    isPurchasing,
+    isRestoring
+  } = useRevenueCat();
+
+  const isSubscribed = checkEntitlement(entitlementId);
+  const subscriptionInfo = getSubscriptionDetails(entitlementId);
+
+  return {
+    isSubscribed,
+    subscriptionInfo,
+    customerInfo,
+    purchasePackage,
+    restoreUserPurchases,
+    isPurchasing,
+    isRestoring,
+  };
+};

--- a/client/ios/Podfile.lock
+++ b/client/ios/Podfile.lock
@@ -480,6 +480,8 @@ PODS:
   - PromisesObjC (2.4.0)
   - PromisesSwift (2.4.0):
     - PromisesObjC (= 2.4.0)
+  - PurchasesHybridCommon (17.3.0):
+    - RevenueCat (= 5.36.0)
   - RCT-Folly (2024.11.18.00):
     - boost
     - DoubleConversion
@@ -2226,6 +2228,7 @@ PODS:
     - React-perflogger (= 0.79.5)
     - React-utils (= 0.79.5)
   - RecaptchaInterop (101.0.0)
+  - RevenueCat (5.36.0)
   - RNCPicker (2.11.1):
     - DoubleConversion
     - glog
@@ -2342,6 +2345,9 @@ PODS:
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
     - Yoga
+  - RNPurchases (9.3.0):
+    - PurchasesHybridCommon (= 17.3.0)
+    - React-Core
   - RNReanimated (3.17.5):
     - DoubleConversion
     - glog
@@ -2693,6 +2699,7 @@ DEPENDENCIES:
   - RNGestureHandler (from `../node_modules/react-native-gesture-handler`)
   - RNGoogleMobileAds (from `../node_modules/react-native-google-mobile-ads`)
   - "RNGoogleSignin (from `../node_modules/@react-native-google-signin/google-signin`)"
+  - RNPurchases (from `../node_modules/react-native-purchases`)
   - RNReanimated (from `../node_modules/react-native-reanimated`)
   - RNScreens (from `../node_modules/react-native-screens`)
   - RNSVG (from `../node_modules/react-native-svg`)
@@ -2727,7 +2734,9 @@ SPEC REPOS:
     - nanopb
     - PromisesObjC
     - PromisesSwift
+    - PurchasesHybridCommon
     - RecaptchaInterop
+    - RevenueCat
     - SDWebImage
     - SDWebImageAVIFCoder
     - SDWebImageSVGCoder
@@ -2947,6 +2956,8 @@ EXTERNAL SOURCES:
     :path: "../node_modules/react-native-google-mobile-ads"
   RNGoogleSignin:
     :path: "../node_modules/@react-native-google-signin/google-signin"
+  RNPurchases:
+    :path: "../node_modules/react-native-purchases"
   RNReanimated:
     :path: "../node_modules/react-native-reanimated"
   RNScreens:
@@ -3017,6 +3028,7 @@ SPEC CHECKSUMS:
   nanopb: fad817b59e0457d11a5dfbde799381cd727c1275
   PromisesObjC: f5707f49cb48b9636751c5b2e7d227e43fba9f47
   PromisesSwift: 9d77319bbe72ebf6d872900551f7eeba9bce2851
+  PurchasesHybridCommon: 61759dbf7a02b085e4904d8def867d6a89252cb0
   RCT-Folly: e78785aa9ba2ed998ea4151e314036f6c49e6d82
   RCTDeprecation: 5f638f65935e273753b1f31a365db6a8d6dc53b5
   RCTRequired: 8b46a520ea9071e2bc47d474aa9ca31b4a935bd8
@@ -3082,6 +3094,7 @@ SPEC CHECKSUMS:
   ReactCodegen: 542dbcd3d677ed7c4fe69e28b7c492998f48c9db
   ReactCommon: 1aa48867a0fc71a2b4f9e8a1529f5673648354f3
   RecaptchaInterop: 11e0b637842dfb48308d242afc3f448062325aba
+  RevenueCat: 1b6e3f4582356a549048dac2cd21410cad67d51b
   RNCPicker: c424533f7747c9463b35d294328e7b2b4d2baf31
   RNFBApp: 12884d3bf9b3a0223efe4a0adce516edf72c4102
   RNFBAuth: f8327aab9b7edf5f15a3b1b9089f6a8d56faf992
@@ -3090,6 +3103,7 @@ SPEC CHECKSUMS:
   RNGestureHandler: 8ff2b1434b0ff8bab28c8242a656fb842990bbc8
   RNGoogleMobileAds: 742cc7b372a9e3c5617281e1b8d8e1c9e2854fb4
   RNGoogleSignin: db4aa231a90bdc4cea8b749ec68b168c8f747ec2
+  RNPurchases: 42a126948a0d80340a4c381ea95a691b5f587d05
   RNReanimated: a3f55346df73f35c38bf0b446294d3d0b1ac8cf9
   RNScreens: 90b905d545a5ebbe976985702b8a39e3475727b2
   RNSVG: 4470464e129f6bc58b78b961850b054dbbea8ef7

--- a/client/ios/fitnessapp.xcodeproj/project.pbxproj
+++ b/client/ios/fitnessapp.xcodeproj/project.pbxproj
@@ -9,11 +9,11 @@
 /* Begin PBXBuildFile section */
 		13B07FBF1A68108700A75B9A /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 13B07FB51A68108700A75B9A /* Images.xcassets */; };
 		3E461D99554A48A4959DE609 /* SplashScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = AA286B85B6C04FC6940260E9 /* SplashScreen.storyboard */; };
-		5093F5C9DDEDC118AD2E71D4 /* ExpoModulesProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F7531A928DA3146FC381332 /* ExpoModulesProvider.swift */; };
-		7404B5F41D554D81BFFC371B /* GoogleService-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = E9451B667DC54B608B14E1AE /* GoogleService-Info.plist */; };
-		B844E57D856BB3DB63F46CFE /* Pods_fitnessapp.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 77EEF1B46CE7A4FCE5FFEE4D /* Pods_fitnessapp.framework */; };
+		42A081BF6AE5D97C788D234E /* ExpoModulesProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 713FDF591AE2012480085E85 /* ExpoModulesProvider.swift */; };
+		66274FA1BF132C044F0B64A9 /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = F7D72944E2D308F7C2EB8BE7 /* PrivacyInfo.xcprivacy */; };
+		67FEED930B7446A093F16B18 /* GoogleService-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = 527E2F0BC06649A6BFDDE9FE /* GoogleService-Info.plist */; };
+		7FC0D6ECE170A37B045DA316 /* Pods_fitnessapp.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5B02E419120331D67B4A0780 /* Pods_fitnessapp.framework */; };
 		BB2F792D24A3F905000567C9 /* Expo.plist in Resources */ = {isa = PBXBuildFile; fileRef = BB2F792C24A3F905000567C9 /* Expo.plist */; };
-		BC0BB49636A2DA94F5AC596A /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = 70C86A7BECF2C6151965BDC5 /* PrivacyInfo.xcprivacy */; };
 		F11748422D0307B40044C1D9 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = F11748412D0307B40044C1D9 /* AppDelegate.swift */; };
 /* End PBXBuildFile section */
 
@@ -21,17 +21,17 @@
 		13B07F961A680F5B00A75B9A /* fitnessapp.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = fitnessapp.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		13B07FB51A68108700A75B9A /* Images.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; name = Images.xcassets; path = fitnessapp/Images.xcassets; sourceTree = "<group>"; };
 		13B07FB61A68108700A75B9A /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = Info.plist; path = fitnessapp/Info.plist; sourceTree = "<group>"; };
-		2499167344E7C0800CCEA1DB /* Pods-fitnessapp.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-fitnessapp.release.xcconfig"; path = "Target Support Files/Pods-fitnessapp/Pods-fitnessapp.release.xcconfig"; sourceTree = "<group>"; };
-		2F7531A928DA3146FC381332 /* ExpoModulesProvider.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ExpoModulesProvider.swift; path = "Pods/Target Support Files/Pods-fitnessapp/ExpoModulesProvider.swift"; sourceTree = "<group>"; };
-		70C86A7BECF2C6151965BDC5 /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; includeInIndex = 1; name = PrivacyInfo.xcprivacy; path = fitnessapp/PrivacyInfo.xcprivacy; sourceTree = "<group>"; };
-		73C0181A5F0B71484A099F69 /* Pods-fitnessapp.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-fitnessapp.debug.xcconfig"; path = "Target Support Files/Pods-fitnessapp/Pods-fitnessapp.debug.xcconfig"; sourceTree = "<group>"; };
-		77EEF1B46CE7A4FCE5FFEE4D /* Pods_fitnessapp.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_fitnessapp.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		3AE843506B09E167CEEA1A60 /* Pods-fitnessapp.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-fitnessapp.debug.xcconfig"; path = "Target Support Files/Pods-fitnessapp/Pods-fitnessapp.debug.xcconfig"; sourceTree = "<group>"; };
+		527E2F0BC06649A6BFDDE9FE /* GoogleService-Info.plist */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 4; includeInIndex = 0; lastKnownFileType = text.plist.xml; name = "GoogleService-Info.plist"; path = "fitnessapp/GoogleService-Info.plist"; sourceTree = "<group>"; };
+		5B02E419120331D67B4A0780 /* Pods_fitnessapp.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_fitnessapp.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		713FDF591AE2012480085E85 /* ExpoModulesProvider.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ExpoModulesProvider.swift; path = "Pods/Target Support Files/Pods-fitnessapp/ExpoModulesProvider.swift"; sourceTree = "<group>"; };
 		AA286B85B6C04FC6940260E9 /* SplashScreen.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; name = SplashScreen.storyboard; path = fitnessapp/SplashScreen.storyboard; sourceTree = "<group>"; };
 		BB2F792C24A3F905000567C9 /* Expo.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Expo.plist; sourceTree = "<group>"; };
-		E9451B667DC54B608B14E1AE /* GoogleService-Info.plist */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 4; includeInIndex = 0; lastKnownFileType = text.plist.xml; name = "GoogleService-Info.plist"; path = "fitnessapp/GoogleService-Info.plist"; sourceTree = "<group>"; };
+		D2BCB8E0FA2D9BE0213A2A97 /* Pods-fitnessapp.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-fitnessapp.release.xcconfig"; path = "Target Support Files/Pods-fitnessapp/Pods-fitnessapp.release.xcconfig"; sourceTree = "<group>"; };
 		ED297162215061F000B7C4FE /* JavaScriptCore.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = JavaScriptCore.framework; path = System/Library/Frameworks/JavaScriptCore.framework; sourceTree = SDKROOT; };
 		F11748412D0307B40044C1D9 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = AppDelegate.swift; path = fitnessapp/AppDelegate.swift; sourceTree = "<group>"; };
 		F11748442D0722820044C1D9 /* fitnessapp-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "fitnessapp-Bridging-Header.h"; path = "fitnessapp/fitnessapp-Bridging-Header.h"; sourceTree = "<group>"; };
+		F7D72944E2D308F7C2EB8BE7 /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; includeInIndex = 1; name = PrivacyInfo.xcprivacy; path = fitnessapp/PrivacyInfo.xcprivacy; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -39,7 +39,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				B844E57D856BB3DB63F46CFE /* Pods_fitnessapp.framework in Frameworks */,
+				7FC0D6ECE170A37B045DA316 /* Pods_fitnessapp.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -55,8 +55,8 @@
 				13B07FB51A68108700A75B9A /* Images.xcassets */,
 				13B07FB61A68108700A75B9A /* Info.plist */,
 				AA286B85B6C04FC6940260E9 /* SplashScreen.storyboard */,
-				E9451B667DC54B608B14E1AE /* GoogleService-Info.plist */,
-				70C86A7BECF2C6151965BDC5 /* PrivacyInfo.xcprivacy */,
+				527E2F0BC06649A6BFDDE9FE /* GoogleService-Info.plist */,
+				F7D72944E2D308F7C2EB8BE7 /* PrivacyInfo.xcprivacy */,
 			);
 			name = fitnessapp;
 			sourceTree = "<group>";
@@ -65,17 +65,9 @@
 			isa = PBXGroup;
 			children = (
 				ED297162215061F000B7C4FE /* JavaScriptCore.framework */,
-				77EEF1B46CE7A4FCE5FFEE4D /* Pods_fitnessapp.framework */,
+				5B02E419120331D67B4A0780 /* Pods_fitnessapp.framework */,
 			);
 			name = Frameworks;
-			sourceTree = "<group>";
-		};
-		3FDCFFF1666E299D0A4B84F8 /* ExpoModulesProviders */ = {
-			isa = PBXGroup;
-			children = (
-				B6184AEF674D222E3803E9BF /* fitnessapp */,
-			);
-			name = ExpoModulesProviders;
 			sourceTree = "<group>";
 		};
 		832341AE1AAA6A7D00B99B32 /* Libraries */ = {
@@ -92,8 +84,8 @@
 				832341AE1AAA6A7D00B99B32 /* Libraries */,
 				83CBBA001A601CBA00E9B192 /* Products */,
 				2D16E6871FA4F8E400B85C8A /* Frameworks */,
-				B159D9C5A15A7B2D9061667C /* Pods */,
-				3FDCFFF1666E299D0A4B84F8 /* ExpoModulesProviders */,
+				8D89302E35430DCD27F01C2D /* Pods */,
+				9A9A1486B38764DE6671B26B /* ExpoModulesProviders */,
 			);
 			indentWidth = 2;
 			sourceTree = "<group>";
@@ -108,20 +100,28 @@
 			name = Products;
 			sourceTree = "<group>";
 		};
-		B159D9C5A15A7B2D9061667C /* Pods */ = {
+		8D89302E35430DCD27F01C2D /* Pods */ = {
 			isa = PBXGroup;
 			children = (
-				73C0181A5F0B71484A099F69 /* Pods-fitnessapp.debug.xcconfig */,
-				2499167344E7C0800CCEA1DB /* Pods-fitnessapp.release.xcconfig */,
+				3AE843506B09E167CEEA1A60 /* Pods-fitnessapp.debug.xcconfig */,
+				D2BCB8E0FA2D9BE0213A2A97 /* Pods-fitnessapp.release.xcconfig */,
 			);
 			name = Pods;
 			path = Pods;
 			sourceTree = "<group>";
 		};
-		B6184AEF674D222E3803E9BF /* fitnessapp */ = {
+		9A9A1486B38764DE6671B26B /* ExpoModulesProviders */ = {
 			isa = PBXGroup;
 			children = (
-				2F7531A928DA3146FC381332 /* ExpoModulesProvider.swift */,
+				AD8E35C9E4B876BE83DD64E6 /* fitnessapp */,
+			);
+			name = ExpoModulesProviders;
+			sourceTree = "<group>";
+		};
+		AD8E35C9E4B876BE83DD64E6 /* fitnessapp */ = {
+			isa = PBXGroup;
+			children = (
+				713FDF591AE2012480085E85 /* ExpoModulesProvider.swift */,
 			);
 			name = fitnessapp;
 			sourceTree = "<group>";
@@ -143,16 +143,16 @@
 			buildConfigurationList = 13B07F931A680F5B00A75B9A /* Build configuration list for PBXNativeTarget "fitnessapp" */;
 			buildPhases = (
 				08A4A3CD28434E44B6B9DE2E /* [CP] Check Pods Manifest.lock */,
-				9B71272493690A5FF6C2CD7A /* [Expo] Configure project */,
+				32071FE42CD4BE4340404B2D /* [Expo] Configure project */,
 				13B07F871A680F5B00A75B9A /* Sources */,
 				13B07F8C1A680F5B00A75B9A /* Frameworks */,
 				13B07F8E1A680F5B00A75B9A /* Resources */,
 				00DD1BFF1BD5951E006B06BC /* Bundle React Native code and images */,
 				800E24972A6A228C8D4807E9 /* [CP] Copy Pods Resources */,
-				E70811E68C8E91E9CB6A645B /* [CP] Embed Pods Frameworks */,
-				9F25F4D92641E82177BA753D /* [CP-User] [RNFB] Core Configuration */,
-				DE8D0AF12EE70F5371B9C1E9 /* [CP-User] [RNFB] Crashlytics Configuration */,
-				48D51B2C031DE36DAC1E86CF /* [CP-User] [RNGoogleMobileAds] Configuration */,
+				44BD27DA217278918907258D /* [CP] Embed Pods Frameworks */,
+				E82735F81D9DE14B5D74D5FE /* [CP-User] [RNFB] Core Configuration */,
+				5F019D3490A4CBE3BE103BB8 /* [CP-User] [RNFB] Crashlytics Configuration */,
+				5F7A25AA63381127FA4FD362 /* [CP-User] [RNGoogleMobileAds] Configuration */,
 			);
 			buildRules = (
 			);
@@ -202,8 +202,8 @@
 				BB2F792D24A3F905000567C9 /* Expo.plist in Resources */,
 				13B07FBF1A68108700A75B9A /* Images.xcassets in Resources */,
 				3E461D99554A48A4959DE609 /* SplashScreen.storyboard in Resources */,
-				7404B5F41D554D81BFFC371B /* GoogleService-Info.plist in Resources */,
-				BC0BB49636A2DA94F5AC596A /* PrivacyInfo.xcprivacy in Resources */,
+				67FEED930B7446A093F16B18 /* GoogleService-Info.plist in Resources */,
+				66274FA1BF132C044F0B64A9 /* PrivacyInfo.xcprivacy in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -247,7 +247,58 @@
 			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
 			showEnvVarsInLog = 0;
 		};
-		48D51B2C031DE36DAC1E86CF /* [CP-User] [RNGoogleMobileAds] Configuration */ = {
+		32071FE42CD4BE4340404B2D /* [Expo] Configure project */ = {
+			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+			);
+			name = "[Expo] Configure project";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "# This script configures Expo modules and generates the modules provider file.\nbash -l -c \"./Pods/Target\\ Support\\ Files/Pods-fitnessapp/expo-configure-project.sh\"\n";
+		};
+		44BD27DA217278918907258D /* [CP] Embed Pods Frameworks */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-fitnessapp/Pods-fitnessapp-frameworks.sh",
+				"${PODS_XCFRAMEWORKS_BUILD_DIR}/hermes-engine/Pre-built/hermes.framework/hermes",
+			);
+			name = "[CP] Embed Pods Frameworks";
+			outputPaths = (
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/hermes.framework",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-fitnessapp/Pods-fitnessapp-frameworks.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
+		5F019D3490A4CBE3BE103BB8 /* [CP-User] [RNFB] Crashlytics Configuration */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+				"${DWARF_DSYM_FOLDER_PATH}/${DWARF_DSYM_FILE_NAME}/Contents/Resources/DWARF/${TARGET_NAME}",
+				"$(BUILT_PRODUCTS_DIR)/$(INFOPLIST_PATH)",
+			);
+			name = "[CP-User] [RNFB] Crashlytics Configuration";
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "#!/usr/bin/env bash\n#\n# Copyright (c) 2016-present Invertase Limited & Contributors\n#\n# Licensed under the Apache License, Version 2.0 (the \"License\");\n# you may not use this library except in compliance with the License.\n# You may obtain a copy of the License at\n#\n#   http://www.apache.org/licenses/LICENSE-2.0\n#\n# Unless required by applicable law or agreed to in writing, software\n# distributed under the License is distributed on an \"AS IS\" BASIS,\n# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\n# See the License for the specific language governing permissions and\n# limitations under the License.\n#\nset -e\n\nif [[ ${PODS_ROOT} ]]; then\n  echo \"info: Exec FirebaseCrashlytics Run from Pods\"\n  \"${PODS_ROOT}/FirebaseCrashlytics/run\"\nelse\n  echo \"info: Exec FirebaseCrashlytics Run from framework\"\n  \"${PROJECT_DIR}/FirebaseCrashlytics.framework/run\"\nfi\n";
+		};
+		5F7A25AA63381127FA4FD362 /* [CP-User] [RNGoogleMobileAds] Configuration */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -287,10 +338,12 @@
 				"${PODS_CONFIGURATION_BUILD_DIR}/GoogleUtilities/GoogleUtilities_Privacy.bundle",
 				"${PODS_CONFIGURATION_BUILD_DIR}/PromisesObjC/FBLPromises_Privacy.bundle",
 				"${PODS_CONFIGURATION_BUILD_DIR}/PromisesSwift/Promises_Privacy.bundle",
+				"${PODS_CONFIGURATION_BUILD_DIR}/PurchasesHybridCommon/PurchasesHybridCommon.bundle",
 				"${PODS_CONFIGURATION_BUILD_DIR}/RCT-Folly/RCT-Folly_privacy.bundle",
 				"${PODS_CONFIGURATION_BUILD_DIR}/RNSVG/RNSVGFilters.bundle",
 				"${PODS_CONFIGURATION_BUILD_DIR}/React-Core/React-Core_privacy.bundle",
 				"${PODS_CONFIGURATION_BUILD_DIR}/React-cxxreact/React-cxxreact_privacy.bundle",
+				"${PODS_CONFIGURATION_BUILD_DIR}/RevenueCat/RevenueCat.bundle",
 				"${PODS_CONFIGURATION_BUILD_DIR}/SDWebImage/SDWebImage.bundle",
 				"${PODS_CONFIGURATION_BUILD_DIR}/boost/boost_privacy.bundle",
 				"${PODS_CONFIGURATION_BUILD_DIR}/expo-dev-launcher/EXDevLauncher.bundle",
@@ -320,10 +373,12 @@
 				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/GoogleUtilities_Privacy.bundle",
 				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/FBLPromises_Privacy.bundle",
 				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/Promises_Privacy.bundle",
+				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/PurchasesHybridCommon.bundle",
 				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/RCT-Folly_privacy.bundle",
 				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/RNSVGFilters.bundle",
 				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/React-Core_privacy.bundle",
 				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/React-cxxreact_privacy.bundle",
+				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/RevenueCat.bundle",
 				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/SDWebImage.bundle",
 				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/boost_privacy.bundle",
 				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/EXDevLauncher.bundle",
@@ -336,26 +391,7 @@
 			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-fitnessapp/Pods-fitnessapp-resources.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
-		9B71272493690A5FF6C2CD7A /* [Expo] Configure project */ = {
-			isa = PBXShellScriptBuildPhase;
-			alwaysOutOfDate = 1;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputFileListPaths = (
-			);
-			inputPaths = (
-			);
-			name = "[Expo] Configure project";
-			outputFileListPaths = (
-			);
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "# This script configures Expo modules and generates the modules provider file.\nbash -l -c \"./Pods/Target\\ Support\\ Files/Pods-fitnessapp/expo-configure-project.sh\"\n";
-		};
-		9F25F4D92641E82177BA753D /* [CP-User] [RNFB] Core Configuration */ = {
+		E82735F81D9DE14B5D74D5FE /* [CP-User] [RNFB] Core Configuration */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -368,38 +404,6 @@
 			shellPath = /bin/sh;
 			shellScript = "#!/usr/bin/env bash\n#\n# Copyright (c) 2016-present Invertase Limited & Contributors\n#\n# Licensed under the Apache License, Version 2.0 (the \"License\");\n# you may not use this library except in compliance with the License.\n# You may obtain a copy of the License at\n#\n#   http://www.apache.org/licenses/LICENSE-2.0\n#\n# Unless required by applicable law or agreed to in writing, software\n# distributed under the License is distributed on an \"AS IS\" BASIS,\n# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\n# See the License for the specific language governing permissions and\n# limitations under the License.\n#\n\n##########################################################################\n##########################################################################\n#\n#  NOTE THAT IF YOU CHANGE THIS FILE YOU MUST RUN pod install AFTERWARDS\n#\n#  This file is installed as an Xcode build script in the project file\n#  by cocoapods, and you will not see your changes until you pod install\n#\n##########################################################################\n##########################################################################\n\nset -e\n\n_MAX_LOOKUPS=2;\n_SEARCH_RESULT=''\n_RN_ROOT_EXISTS=''\n_CURRENT_LOOKUPS=1\n_JSON_ROOT=\"'react-native'\"\n_JSON_FILE_NAME='firebase.json'\n_JSON_OUTPUT_BASE64='e30=' # { }\n_CURRENT_SEARCH_DIR=${PROJECT_DIR}\n_PLIST_BUDDY=/usr/libexec/PlistBuddy\n_TARGET_PLIST=\"${BUILT_PRODUCTS_DIR}/${INFOPLIST_PATH}\"\n_DSYM_PLIST=\"${DWARF_DSYM_FOLDER_PATH}/${DWARF_DSYM_FILE_NAME}/Contents/Info.plist\"\n\n# plist arrays\n_PLIST_ENTRY_KEYS=()\n_PLIST_ENTRY_TYPES=()\n_PLIST_ENTRY_VALUES=()\n\nfunction setPlistValue {\n  echo \"info:      setting plist entry '$1' of type '$2' in file '$4'\"\n  ${_PLIST_BUDDY} -c \"Add :$1 $2 '$3'\" $4 || echo \"info:      '$1' already exists\"\n}\n\nfunction getFirebaseJsonKeyValue () {\n  if [[ ${_RN_ROOT_EXISTS} ]]; then\n    ruby -Ku -e \"require 'rubygems';require 'json'; output=JSON.parse('$1'); puts output[$_JSON_ROOT]['$2']\"\n  else\n    echo \"\"\n  fi;\n}\n\nfunction jsonBoolToYesNo () {\n  if [[ $1 == \"false\" ]]; then\n    echo \"NO\"\n  elif [[ $1 == \"true\" ]]; then\n    echo \"YES\"\n  else echo \"NO\"\n  fi\n}\n\necho \"info: -> RNFB build script started\"\necho \"info: 1) Locating ${_JSON_FILE_NAME} file:\"\n\nif [[ -z ${_CURRENT_SEARCH_DIR} ]]; then\n  _CURRENT_SEARCH_DIR=$(pwd)\nfi;\n\nwhile true; do\n  _CURRENT_SEARCH_DIR=$(dirname \"$_CURRENT_SEARCH_DIR\")\n  if [[ \"$_CURRENT_SEARCH_DIR\" == \"/\" ]] || [[ ${_CURRENT_LOOKUPS} -gt ${_MAX_LOOKUPS} ]]; then break; fi;\n  echo \"info:      ($_CURRENT_LOOKUPS of $_MAX_LOOKUPS) Searching in '$_CURRENT_SEARCH_DIR' for a ${_JSON_FILE_NAME} file.\"\n  _SEARCH_RESULT=$(find \"$_CURRENT_SEARCH_DIR\" -maxdepth 2 -name ${_JSON_FILE_NAME} -print | /usr/bin/head -n 1)\n  if [[ ${_SEARCH_RESULT} ]]; then\n    echo \"info:      ${_JSON_FILE_NAME} found at $_SEARCH_RESULT\"\n    break;\n  fi;\n  _CURRENT_LOOKUPS=$((_CURRENT_LOOKUPS+1))\ndone\n\nif [[ ${_SEARCH_RESULT} ]]; then\n  _JSON_OUTPUT_RAW=$(cat \"${_SEARCH_RESULT}\")\n  _RN_ROOT_EXISTS=$(ruby -Ku -e \"require 'rubygems';require 'json'; output=JSON.parse('$_JSON_OUTPUT_RAW'); puts output[$_JSON_ROOT]\" || echo '')\n\n  if [[ ${_RN_ROOT_EXISTS} ]]; then\n    if ! python3 --version >/dev/null 2>&1; then echo \"python3 not found, firebase.json file processing error.\" && exit 1; fi\n    _JSON_OUTPUT_BASE64=$(python3 -c 'import json,sys,base64;print(base64.b64encode(bytes(json.dumps(json.loads(open('\"'${_SEARCH_RESULT}'\"', '\"'rb'\"').read())['${_JSON_ROOT}']), '\"'utf-8'\"')).decode())' || echo \"e30=\")\n  fi\n\n  _PLIST_ENTRY_KEYS+=(\"firebase_json_raw\")\n  _PLIST_ENTRY_TYPES+=(\"string\")\n  _PLIST_ENTRY_VALUES+=(\"$_JSON_OUTPUT_BASE64\")\n\n  # config.app_data_collection_default_enabled\n  _APP_DATA_COLLECTION_ENABLED=$(getFirebaseJsonKeyValue \"$_JSON_OUTPUT_RAW\" \"app_data_collection_default_enabled\")\n  if [[ $_APP_DATA_COLLECTION_ENABLED ]]; then\n    _PLIST_ENTRY_KEYS+=(\"FirebaseDataCollectionDefaultEnabled\")\n    _PLIST_ENTRY_TYPES+=(\"bool\")\n    _PLIST_ENTRY_VALUES+=(\"$(jsonBoolToYesNo \"$_APP_DATA_COLLECTION_ENABLED\")\")\n  fi\n\n  # config.analytics_auto_collection_enabled\n  _ANALYTICS_AUTO_COLLECTION=$(getFirebaseJsonKeyValue \"$_JSON_OUTPUT_RAW\" \"analytics_auto_collection_enabled\")\n  if [[ $_ANALYTICS_AUTO_COLLECTION ]]; then\n    _PLIST_ENTRY_KEYS+=(\"FIREBASE_ANALYTICS_COLLECTION_ENABLED\")\n    _PLIST_ENTRY_TYPES+=(\"bool\")\n    _PLIST_ENTRY_VALUES+=(\"$(jsonBoolToYesNo \"$_ANALYTICS_AUTO_COLLECTION\")\")\n  fi\n\n  # config.analytics_collection_deactivated\n  _ANALYTICS_DEACTIVATED=$(getFirebaseJsonKeyValue \"$_JSON_OUTPUT_RAW\" \"analytics_collection_deactivated\")\n  if [[ $_ANALYTICS_DEACTIVATED ]]; then\n    _PLIST_ENTRY_KEYS+=(\"FIREBASE_ANALYTICS_COLLECTION_DEACTIVATED\")\n    _PLIST_ENTRY_TYPES+=(\"bool\")\n    _PLIST_ENTRY_VALUES+=(\"$(jsonBoolToYesNo \"$_ANALYTICS_DEACTIVATED\")\")\n  fi\n\n  # config.analytics_idfv_collection_enabled\n  _ANALYTICS_IDFV_COLLECTION=$(getFirebaseJsonKeyValue \"$_JSON_OUTPUT_RAW\" \"analytics_idfv_collection_enabled\")\n  if [[ $_ANALYTICS_IDFV_COLLECTION ]]; then\n    _PLIST_ENTRY_KEYS+=(\"GOOGLE_ANALYTICS_IDFV_COLLECTION_ENABLED\")\n    _PLIST_ENTRY_TYPES+=(\"bool\")\n    _PLIST_ENTRY_VALUES+=(\"$(jsonBoolToYesNo \"$_ANALYTICS_IDFV_COLLECTION\")\")\n  fi\n\n  # config.analytics_default_allow_analytics_storage\n  _ANALYTICS_STORAGE=$(getFirebaseJsonKeyValue \"$_JSON_OUTPUT_RAW\" \"analytics_default_allow_analytics_storage\")\n  if [[ $_ANALYTICS_STORAGE ]]; then\n    _PLIST_ENTRY_KEYS+=(\"GOOGLE_ANALYTICS_DEFAULT_ALLOW_ANALYTICS_STORAGE\")\n    _PLIST_ENTRY_TYPES+=(\"bool\")\n    _PLIST_ENTRY_VALUES+=(\"$(jsonBoolToYesNo \"$_ANALYTICS_STORAGE\")\")\n  fi\n\n  # config.analytics_default_allow_ad_storage\n  _ANALYTICS_AD_STORAGE=$(getFirebaseJsonKeyValue \"$_JSON_OUTPUT_RAW\" \"analytics_default_allow_ad_storage\")\n  if [[ $_ANALYTICS_AD_STORAGE ]]; then\n    _PLIST_ENTRY_KEYS+=(\"GOOGLE_ANALYTICS_DEFAULT_ALLOW_AD_STORAGE\")\n    _PLIST_ENTRY_TYPES+=(\"bool\")\n    _PLIST_ENTRY_VALUES+=(\"$(jsonBoolToYesNo \"$_ANALYTICS_AD_STORAGE\")\")\n  fi\n\n  # config.analytics_default_allow_ad_user_data\n  _ANALYTICS_AD_USER_DATA=$(getFirebaseJsonKeyValue \"$_JSON_OUTPUT_RAW\" \"analytics_default_allow_ad_user_data\")\n  if [[ $_ANALYTICS_AD_USER_DATA ]]; then\n    _PLIST_ENTRY_KEYS+=(\"GOOGLE_ANALYTICS_DEFAULT_ALLOW_AD_USER_DATA\")\n    _PLIST_ENTRY_TYPES+=(\"bool\")\n    _PLIST_ENTRY_VALUES+=(\"$(jsonBoolToYesNo \"$_ANALYTICS_AD_USER_DATA\")\")\n  fi\n\n  # config.analytics_default_allow_ad_personalization_signals\n  _ANALYTICS_PERSONALIZATION=$(getFirebaseJsonKeyValue \"$_JSON_OUTPUT_RAW\" \"analytics_default_allow_ad_personalization_signals\")\n  if [[ $_ANALYTICS_PERSONALIZATION ]]; then\n    _PLIST_ENTRY_KEYS+=(\"GOOGLE_ANALYTICS_DEFAULT_ALLOW_AD_PERSONALIZATION_SIGNALS\")\n    _PLIST_ENTRY_TYPES+=(\"bool\")\n    _PLIST_ENTRY_VALUES+=(\"$(jsonBoolToYesNo \"$_ANALYTICS_PERSONALIZATION\")\")\n  fi\n\n  # config.analytics_registration_with_ad_network_enabled\n  _ANALYTICS_REGISTRATION_WITH_AD_NETWORK=$(getFirebaseJsonKeyValue \"$_JSON_OUTPUT_RAW\" \"google_analytics_registration_with_ad_network_enabled\")\n  if [[ $_ANALYTICS_REGISTRATION_WITH_AD_NETWORK ]]; then\n    _PLIST_ENTRY_KEYS+=(\"GOOGLE_ANALYTICS_REGISTRATION_WITH_AD_NETWORK_ENABLED\")\n    _PLIST_ENTRY_TYPES+=(\"bool\")\n    _PLIST_ENTRY_VALUES+=(\"$(jsonBoolToYesNo \"$_ANALYTICS_REGISTRATION_WITH_AD_NETWORK\")\")\n  fi\n\n  # config.google_analytics_automatic_screen_reporting_enabled\n  _ANALYTICS_AUTO_SCREEN_REPORTING=$(getFirebaseJsonKeyValue \"$_JSON_OUTPUT_RAW\" \"google_analytics_automatic_screen_reporting_enabled\")\n  if [[ $_ANALYTICS_AUTO_SCREEN_REPORTING ]]; then\n    _PLIST_ENTRY_KEYS+=(\"FirebaseAutomaticScreenReportingEnabled\")\n    _PLIST_ENTRY_TYPES+=(\"bool\")\n    _PLIST_ENTRY_VALUES+=(\"$(jsonBoolToYesNo \"$_ANALYTICS_AUTO_SCREEN_REPORTING\")\")\n  fi\n\n  # config.perf_auto_collection_enabled\n  _PERF_AUTO_COLLECTION=$(getFirebaseJsonKeyValue \"$_JSON_OUTPUT_RAW\" \"perf_auto_collection_enabled\")\n  if [[ $_PERF_AUTO_COLLECTION ]]; then\n    _PLIST_ENTRY_KEYS+=(\"firebase_performance_collection_enabled\")\n    _PLIST_ENTRY_TYPES+=(\"bool\")\n    _PLIST_ENTRY_VALUES+=(\"$(jsonBoolToYesNo \"$_PERF_AUTO_COLLECTION\")\")\n  fi\n\n  # config.perf_collection_deactivated\n  _PERF_DEACTIVATED=$(getFirebaseJsonKeyValue \"$_JSON_OUTPUT_RAW\" \"perf_collection_deactivated\")\n  if [[ $_PERF_DEACTIVATED ]]; then\n    _PLIST_ENTRY_KEYS+=(\"firebase_performance_collection_deactivated\")\n    _PLIST_ENTRY_TYPES+=(\"bool\")\n    _PLIST_ENTRY_VALUES+=(\"$(jsonBoolToYesNo \"$_PERF_DEACTIVATED\")\")\n  fi\n\n  # config.messaging_auto_init_enabled\n  _MESSAGING_AUTO_INIT=$(getFirebaseJsonKeyValue \"$_JSON_OUTPUT_RAW\" \"messaging_auto_init_enabled\")\n  if [[ $_MESSAGING_AUTO_INIT ]]; then\n    _PLIST_ENTRY_KEYS+=(\"FirebaseMessagingAutoInitEnabled\")\n    _PLIST_ENTRY_TYPES+=(\"bool\")\n    _PLIST_ENTRY_VALUES+=(\"$(jsonBoolToYesNo \"$_MESSAGING_AUTO_INIT\")\")\n  fi\n\n  # config.in_app_messaging_auto_colllection_enabled\n  _FIAM_AUTO_INIT=$(getFirebaseJsonKeyValue \"$_JSON_OUTPUT_RAW\" \"in_app_messaging_auto_collection_enabled\")\n  if [[ $_FIAM_AUTO_INIT ]]; then\n    _PLIST_ENTRY_KEYS+=(\"FirebaseInAppMessagingAutomaticDataCollectionEnabled\")\n    _PLIST_ENTRY_TYPES+=(\"bool\")\n    _PLIST_ENTRY_VALUES+=(\"$(jsonBoolToYesNo \"$_FIAM_AUTO_INIT\")\")\n  fi\n\n  # config.app_check_token_auto_refresh\n  _APP_CHECK_TOKEN_AUTO_REFRESH=$(getFirebaseJsonKeyValue \"$_JSON_OUTPUT_RAW\" \"app_check_token_auto_refresh\")\n  if [[ $_APP_CHECK_TOKEN_AUTO_REFRESH ]]; then\n    _PLIST_ENTRY_KEYS+=(\"FirebaseAppCheckTokenAutoRefreshEnabled\")\n    _PLIST_ENTRY_TYPES+=(\"bool\")\n    _PLIST_ENTRY_VALUES+=(\"$(jsonBoolToYesNo \"$_APP_CHECK_TOKEN_AUTO_REFRESH\")\")\n  fi\n\n  # config.crashlytics_disable_auto_disabler - undocumented for now - mainly for debugging, document if becomes useful\n  _CRASHLYTICS_AUTO_DISABLE_ENABLED=$(getFirebaseJsonKeyValue \"$_JSON_OUTPUT_RAW\" \"crashlytics_disable_auto_disabler\")\n  if [[ $_CRASHLYTICS_AUTO_DISABLE_ENABLED == \"true\" ]]; then\n    echo \"Disabled Crashlytics auto disabler.\" # do nothing\n  else\n    _PLIST_ENTRY_KEYS+=(\"FirebaseCrashlyticsCollectionEnabled\")\n    _PLIST_ENTRY_TYPES+=(\"bool\")\n    _PLIST_ENTRY_VALUES+=(\"NO\")\n  fi\nelse\n  _PLIST_ENTRY_KEYS+=(\"firebase_json_raw\")\n  _PLIST_ENTRY_TYPES+=(\"string\")\n  _PLIST_ENTRY_VALUES+=(\"$_JSON_OUTPUT_BASE64\")\n  echo \"warning:   A firebase.json file was not found, whilst this file is optional it is recommended to include it to configure firebase services in React Native Firebase.\"\nfi;\n\necho \"info: 2) Injecting Info.plist entries: \"\n\n# Log out the keys we're adding\nfor i in \"${!_PLIST_ENTRY_KEYS[@]}\"; do\n  echo \"    ->  $i) ${_PLIST_ENTRY_KEYS[$i]}\" \"${_PLIST_ENTRY_TYPES[$i]}\" \"${_PLIST_ENTRY_VALUES[$i]}\"\ndone\n\nfor plist in \"${_TARGET_PLIST}\" \"${_DSYM_PLIST}\" ; do\n  if [[ -f \"${plist}\" ]]; then\n\n    # paths with spaces break the call to setPlistValue. temporarily modify\n    # the shell internal field separator variable (IFS), which normally\n    # includes spaces, to consist only of line breaks\n    oldifs=$IFS\n    IFS=\"\n\"\n\n    for i in \"${!_PLIST_ENTRY_KEYS[@]}\"; do\n      setPlistValue \"${_PLIST_ENTRY_KEYS[$i]}\" \"${_PLIST_ENTRY_TYPES[$i]}\" \"${_PLIST_ENTRY_VALUES[$i]}\" \"${plist}\"\n    done\n\n    # restore the original internal field separator value\n    IFS=$oldifs\n  else\n    echo \"warning:   A Info.plist build output file was not found (${plist})\"\n  fi\ndone\n\necho \"info: <- RNFB build script finished\"\n";
 		};
-		DE8D0AF12EE70F5371B9C1E9 /* [CP-User] [RNFB] Crashlytics Configuration */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-				"${DWARF_DSYM_FOLDER_PATH}/${DWARF_DSYM_FILE_NAME}/Contents/Resources/DWARF/${TARGET_NAME}",
-				"$(BUILT_PRODUCTS_DIR)/$(INFOPLIST_PATH)",
-			);
-			name = "[CP-User] [RNFB] Crashlytics Configuration";
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "#!/usr/bin/env bash\n#\n# Copyright (c) 2016-present Invertase Limited & Contributors\n#\n# Licensed under the Apache License, Version 2.0 (the \"License\");\n# you may not use this library except in compliance with the License.\n# You may obtain a copy of the License at\n#\n#   http://www.apache.org/licenses/LICENSE-2.0\n#\n# Unless required by applicable law or agreed to in writing, software\n# distributed under the License is distributed on an \"AS IS\" BASIS,\n# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\n# See the License for the specific language governing permissions and\n# limitations under the License.\n#\nset -e\n\nif [[ ${PODS_ROOT} ]]; then\n  echo \"info: Exec FirebaseCrashlytics Run from Pods\"\n  \"${PODS_ROOT}/FirebaseCrashlytics/run\"\nelse\n  echo \"info: Exec FirebaseCrashlytics Run from framework\"\n  \"${PROJECT_DIR}/FirebaseCrashlytics.framework/run\"\nfi\n";
-		};
-		E70811E68C8E91E9CB6A645B /* [CP] Embed Pods Frameworks */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-fitnessapp/Pods-fitnessapp-frameworks.sh",
-				"${PODS_XCFRAMEWORKS_BUILD_DIR}/hermes-engine/Pre-built/hermes.framework/hermes",
-			);
-			name = "[CP] Embed Pods Frameworks";
-			outputPaths = (
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/hermes.framework",
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-fitnessapp/Pods-fitnessapp-frameworks.sh\"\n";
-			showEnvVarsInLog = 0;
-		};
 /* End PBXShellScriptBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
@@ -408,7 +412,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				F11748422D0307B40044C1D9 /* AppDelegate.swift in Sources */,
-				5093F5C9DDEDC118AD2E71D4 /* ExpoModulesProvider.swift in Sources */,
+				42A081BF6AE5D97C788D234E /* ExpoModulesProvider.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -417,7 +421,7 @@
 /* Begin XCBuildConfiguration section */
 		13B07F941A680F5B00A75B9A /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 73C0181A5F0B71484A099F69 /* Pods-fitnessapp.debug.xcconfig */;
+			baseConfigurationReference = 3AE843506B09E167CEEA1A60 /* Pods-fitnessapp.debug.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
@@ -453,7 +457,7 @@
 		};
 		13B07F951A680F5B00A75B9A /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 2499167344E7C0800CCEA1DB /* Pods-fitnessapp.release.xcconfig */;
+			baseConfigurationReference = D2BCB8E0FA2D9BE0213A2A97 /* Pods-fitnessapp.release.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;

--- a/client/lib/index.ts
+++ b/client/lib/index.ts
@@ -2,3 +2,4 @@ export * from "./apollo-client";
 export * from "./apollo-wrapper";
 export * from "./admob";
 export * from "./AdMobProvider";
+export * from "./revenuecat";

--- a/client/lib/revenuecat.ts
+++ b/client/lib/revenuecat.ts
@@ -1,0 +1,96 @@
+import { Platform } from 'react-native';
+import Purchases, {
+  CustomerInfo,
+  PurchasesOffering,
+  PurchasesPackage,
+  LOG_LEVEL
+} from 'react-native-purchases';
+
+
+// RevenueCatの初期化
+export const configureRevenueCat = async () => {
+  // デバッグログを有効化
+  if (process.env.EXPO_PUBLIC_ENV === 'production' || process.env.EXPO_PUBLIC_ENV === 'preview') {
+    Purchases.setLogLevel(LOG_LEVEL.WARN);
+  } else {
+    Purchases.setLogLevel(LOG_LEVEL.DEBUG);
+  }
+
+  const apiKey = Platform.select({
+    ios: process.env.EXPO_PUBLIC_REVENUECAT_IOS_API_KEY,
+    android: process.env.EXPO_PUBLIC_REVENUECAT_ANDROID_API_KEY
+  })
+  if (!apiKey) {
+    throw new Error('RevenueCat API key is not set');
+  }
+
+  Purchases.configure({ apiKey })
+};
+
+// ユーザーログイン
+export const logInUser = async (appUserId: string) => {
+  const { customerInfo } = await Purchases.logIn(appUserId);
+
+  return customerInfo;
+};
+
+// ユーザーログアウト
+export const logOutUser = async () => {
+  const customerInfo = await Purchases.logOut();
+
+  return customerInfo;
+};
+
+// オファリングを取得
+export const getOfferings = async (): Promise<PurchasesOffering[]> => {
+  const offerings = await Purchases.getOfferings();
+
+  return Object.values(offerings.all);
+};
+
+// 顧客情報を取得
+export const getCustomerInfo = async (): Promise<CustomerInfo> => {
+  const customerInfo = await Purchases.getCustomerInfo();
+
+  return customerInfo;
+};
+
+// 購入を実行
+export const makePurchase = async (packageToPurchase: PurchasesPackage): Promise<CustomerInfo> => {
+  const { customerInfo } = await Purchases.purchasePackage(packageToPurchase);
+
+  return customerInfo;
+};
+
+// 購入を復元
+export const restorePurchases = async (): Promise<CustomerInfo> => {
+  const customerInfo = await Purchases.restorePurchases();
+
+  return customerInfo;
+};
+
+// エンタイトルメントの確認
+export const checkEntitlement = (customerInfo: CustomerInfo, entitlementId: string): boolean => {
+  return customerInfo.entitlements.active[entitlementId] !== undefined;
+};
+
+// サブスクリプションステータスの確認
+export const getSubscriptionStatus = (customerInfo: CustomerInfo, entitlementId: string) => {
+  const entitlement = customerInfo.entitlements.active[entitlementId];
+
+  if (!entitlement) {
+    return {
+      isActive: false,
+      willRenew: false,
+      periodType: null,
+      expirationDate: null,
+    };
+  }
+
+  return {
+    isActive: true,
+    willRenew: entitlement.willRenew,
+    periodType: entitlement.periodType,
+    expirationDate: entitlement.expirationDate,
+  };
+};

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -43,6 +43,7 @@
         "react-native-gesture-handler": "~2.24.0",
         "react-native-google-mobile-ads": "^15.7.0",
         "react-native-picker-select": "^9.3.1",
+        "react-native-purchases": "^9.3.0",
         "react-native-qrcode-svg": "^6.3.15",
         "react-native-reanimated": "~3.17.4",
         "react-native-safe-area-context": "5.4.0",
@@ -5036,6 +5037,24 @@
       "resolved": "https://registry.npmjs.org/@repeaterjs/repeater/-/repeater-3.0.6.tgz",
       "integrity": "sha512-Javneu5lsuhwNCryN+pXH93VPQ8g0dBX7wItHFgYiwQmzE1sVdg5tWHiOgHywzL2W21XQopa7IwIEnNbmeUJYA==",
       "dev": true
+    },
+    "node_modules/@revenuecat/purchases-js": {
+      "version": "1.13.1",
+      "resolved": "https://registry.npmjs.org/@revenuecat/purchases-js/-/purchases-js-1.13.1.tgz",
+      "integrity": "sha512-6yfAWeUBsXA3XaHmBtUMjo6WWpFmd0tZgBJNqTHsB7A42c6wcWRZjzwj/WZEkCUEWUb0WvbseQZs+MJfh2QnMA=="
+    },
+    "node_modules/@revenuecat/purchases-js-hybrid-mappings": {
+      "version": "17.3.0",
+      "resolved": "https://registry.npmjs.org/@revenuecat/purchases-js-hybrid-mappings/-/purchases-js-hybrid-mappings-17.3.0.tgz",
+      "integrity": "sha512-yZhOKBFAY5/cKU8Z93IPf8yjMX8+RW+qsTi/SxCT6jNf1oQHrUAV0bezHXKDMZA2japiGZsixaCjaKPtgQdnqA==",
+      "dependencies": {
+        "@revenuecat/purchases-js": "1.13.1"
+      }
+    },
+    "node_modules/@revenuecat/purchases-typescript-internal": {
+      "version": "17.3.0",
+      "resolved": "https://registry.npmjs.org/@revenuecat/purchases-typescript-internal/-/purchases-typescript-internal-17.3.0.tgz",
+      "integrity": "sha512-sLoXEFhiNMrC/H5qwIe1TsB6g+heLdB8mvqAPhHj3Vd9I1EreRG5vOmR4y/XLY6IlYTnQp1Jv2V8YbkQFVroUA=="
     },
     "node_modules/@rtsao/scc": {
       "version": "1.1.0",
@@ -13362,6 +13381,29 @@
       },
       "peerDependencies": {
         "@react-native-picker/picker": "^2.4.0"
+      }
+    },
+    "node_modules/react-native-purchases": {
+      "version": "9.3.0",
+      "resolved": "https://registry.npmjs.org/react-native-purchases/-/react-native-purchases-9.3.0.tgz",
+      "integrity": "sha512-wI1AfhHXhCAjnO+EzscUsYUCh4xY5vwQbpvGJv28U+161pW9EyYWJhS7QEB1BRKfulFh9CzPlgZ2t7raJuVNxw==",
+      "workspaces": [
+        "examples/purchaseTesterTypescript",
+        "react-native-purchases-ui"
+      ],
+      "dependencies": {
+        "@revenuecat/purchases-js-hybrid-mappings": "17.3.0",
+        "@revenuecat/purchases-typescript-internal": "17.3.0"
+      },
+      "peerDependencies": {
+        "react": ">= 16.6.3",
+        "react-native": ">= 0.73.0",
+        "react-native-web": "*"
+      },
+      "peerDependenciesMeta": {
+        "react-native-web": {
+          "optional": true
+        }
       }
     },
     "node_modules/react-native-qrcode-svg": {

--- a/client/package.json
+++ b/client/package.json
@@ -40,20 +40,21 @@
     "expo-status-bar": "~2.2.3",
     "expo-symbols": "~0.4.5",
     "expo-system-ui": "~5.0.10",
+    "expo-tracking-transparency": "~5.2.4",
     "react": "19.0.0",
     "react-dom": "19.0.0",
     "react-native": "0.79.5",
     "react-native-gesture-handler": "~2.24.0",
     "react-native-google-mobile-ads": "^15.7.0",
     "react-native-picker-select": "^9.3.1",
+    "react-native-purchases": "^9.3.0",
     "react-native-qrcode-svg": "^6.3.15",
     "react-native-reanimated": "~3.17.4",
     "react-native-safe-area-context": "5.4.0",
     "react-native-screens": "~4.11.1",
     "react-native-svg": "15.11.2",
     "react-native-web": "~0.20.0",
-    "react-native-webview": "13.13.5",
-    "expo-tracking-transparency": "~5.2.4"
+    "react-native-webview": "13.13.5"
   },
   "devDependencies": {
     "@babel/core": "^7.25.2",


### PR DESCRIPTION
## 概要
<!-- このPRの目的と概要を簡潔に説明してください -->

サブスク機能を実装するにあたって、RevenueCat を導入した。

## 変更点
<!-- 具体的な変更点や修正箇所をリストアップしてください -->

- RevenueCat 関連の SDK およびコンポーネントの実装

## テスト
<!-- このPRに関連するテストケースやテスト方法を記載してください -->

- 手元で RevenueCat と疎通して、データ取得できること確認
  - Apple Developer の契約プランの関係で、Offerings は取得できずエラーになる

## 備考

RevenueCat の初期設定および SDK 導入で参照した
[【課金】RevenueCatの初期設定](https://zenn.dev/hal1986/books/react-native-monetize/viewer/6_revenuecat_initial_setup)
[React NativeでRevenue Catを使ってサブスク課金を実装する](https://zenn.dev/takahi5/articles/8e3cac715ff668)

App Store Connect まわりで参照した
[App Storeへのリリース申請に必要なスクリーンショットの作成方法](https://zenn.dev/yuv_o/articles/679073eb09af5e)
[App StoreでiOSアプリの課金を審査に出す際に「メタデータが不足」と表示されて提出出来ない場合の対処法【iOS】](https://kan-kikuchi.hatenablog.com/entry/iOS_Metadata_Lack)
[[iOS] サブスクリプションの実装 (StoreKit2, Xcode14)](https://qiita.com/alt_yamamoto/items/334daaa33ff12758d114)